### PR TITLE
fix: Fiexed Dynamic server usage: Route /lists couldn't be rendered s…

### DIFF
--- a/src/app/lists/page.tsx
+++ b/src/app/lists/page.tsx
@@ -3,6 +3,7 @@ import ListsTab from '@/components/lists/ListsTab';
 import React from 'react';
 import { fetchCurrentUserLikeIds, fetchLikedMembers } from '../actions/likeActions';
 
+export const dynamic = 'force-dynamic';
 
 export default async function ListsPage({ searchParams }: { searchParams: { type: string } }) {
   const likedIds = await fetchCurrentUserLikeIds();


### PR DESCRIPTION
…tatically because it used headers